### PR TITLE
Add CoreMod for Bad Recipes from a New Mod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,13 @@ buildscript {
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
-//Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
 version = "1.1.0"
-group = "com.hjae.gcm" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+group = "com.hjae.gcm"
 archivesBaseName = "gcm"
 
-sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
+sourceCompatibility = targetCompatibility = '1.8'
 compileJava {
     sourceCompatibility = targetCompatibility = '1.8'
 }
@@ -23,14 +22,7 @@ compileJava {
 minecraft {
     version = "1.12.2-14.23.5.2847"
     runDir = "run"
-    
-    // the mappings can be changed at any time, and must be in the following format.
-    // snapshot_YYYYMMDD   snapshot are built nightly.
-    // stable_#            stables are built at the discretion of the MCP team.
-    // Use non-default mappings at your own risk. they may not always work.
-    // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20171003"
-    // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+    mappings = "stable_39"
 }
 
 repositories {
@@ -57,6 +49,13 @@ dependencies {
     deobfCompile "codechicken:ChickenASM:1.12-1.0.2.9"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.23-16"
 
+}
+
+jar {
+    manifest {
+        attributes 'FMLCorePlugin': 'com.hjae.gcm.core.GCMLoadingPlugin'
+        attributes 'FMLCorePluginContainsFMLMod': 'true'
+    }
 }
 
 processResources {

--- a/src/main/java/com/hjae/gcm/GCM.java
+++ b/src/main/java/com/hjae/gcm/GCM.java
@@ -15,7 +15,7 @@ public class GCM {
     public static final String NAME = "GCM";
     public static final String VERSION = "1.0";
 
-    private static Logger logger;
+    public static Logger logger;
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {

--- a/src/main/java/com/hjae/gcm/core/GCMLoadingPlugin.java
+++ b/src/main/java/com/hjae/gcm/core/GCMLoadingPlugin.java
@@ -1,0 +1,43 @@
+package com.hjae.gcm.core;
+
+import net.minecraftforge.common.ForgeVersion;
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.MCVersion;
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.Name;
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
+import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
+
+import java.util.Map;
+
+@Name("GCMCoreMod")
+@MCVersion(ForgeVersion.mcVersion)
+@TransformerExclusions("com.hjae.gcm.core.")
+@SortingIndex(1000)
+public class GCMLoadingPlugin implements IFMLLoadingPlugin {
+
+    @Override
+    public String[] getASMTransformerClass() {
+        return new String[] {
+                "com.hjae.gcm.core.GCMTransformer"
+        };
+    }
+
+    @Override
+    public String getAccessTransformerClass() {
+        return null;
+    }
+
+    @Override
+    public String getModContainerClass() {
+        return null;
+    }
+
+    @Override
+    public String getSetupClass() {
+        return null;
+    }
+
+    @Override
+    public void injectData(Map<String, Object> data) {
+    }
+}

--- a/src/main/java/com/hjae/gcm/core/GCMTransformer.java
+++ b/src/main/java/com/hjae/gcm/core/GCMTransformer.java
@@ -1,0 +1,41 @@
+package com.hjae.gcm.core;
+
+import com.hjae.gcm.GCM;
+import com.hjae.gcm.core.transform.ThutElevatorTransformer;
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+public class GCMTransformer implements IClassTransformer {
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        ClassMapper mapper;
+        switch (transformedName) { // Set up like this for future transformations
+            case "thut.tech.common.handlers.ItemHandler":
+                mapper = ThutElevatorTransformer.INSTANCE;
+                break;
+            default:
+                return basicClass;
+        }
+        GCM.logger.info("Transforming class: " + transformedName);
+        return mapper.transformClass(basicClass);
+    }
+
+    public static abstract class ClassMapper {
+
+        public byte[] transformClass(byte[] code) {
+            ClassReader reader = new ClassReader(code);
+            ClassWriter writer = new ClassWriter(reader, getWriteFlags());
+            reader.accept(getClassMapper(writer), 0);
+            return writer.toByteArray();
+        }
+
+        protected int getWriteFlags() {
+            return ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS;
+        }
+
+        protected abstract ClassVisitor getClassMapper(ClassVisitor cv);
+    }
+}

--- a/src/main/java/com/hjae/gcm/core/transform/ThutElevatorTransformer.java
+++ b/src/main/java/com/hjae/gcm/core/transform/ThutElevatorTransformer.java
@@ -1,0 +1,28 @@
+package com.hjae.gcm.core.transform;
+
+import com.hjae.gcm.core.GCMTransformer;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class ThutElevatorTransformer extends GCMTransformer.ClassMapper implements Opcodes {
+
+    public static final ThutElevatorTransformer INSTANCE = new ThutElevatorTransformer();
+
+    @Override
+    protected ClassVisitor getClassMapper(ClassVisitor cv) {
+        return new ClassVisitor(ASM5, cv) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+                if (name.equals("registerRecipes"))
+                    return new MethodVisitor(api, super.visitMethod(access, name, desc, signature, exceptions)) {
+                        @Override
+                        public void visitCode() {
+                            this.visitInsn(RETURN);
+                        }
+                    };
+                return super.visitMethod(access, name, desc, signature, exceptions);
+            }
+        };
+    }
+}


### PR DESCRIPTION
We added the mod "Thut's Elevators" as a nice decoration mod at the suggestion of some of the community. However, when attempting to change its recipes via CraftTweaker, I ended up learning that this mod registers its recipes in the `postInit` event, meaning they are completely inaccessible from CraftTweaker scripts. As a result, this PR creates a small coremod to block those recipes from ever being registered. The actual recipe addition is handled via CraftTweaker scripts which have already been committed to the pack repo.

Additionally, I cleaned up the build.gradle some, and updated the MCP mappings to `stable_39` since there is no reason not to use it.

I also want to point out that there is currently many missing files from this repo, meaning that in order to get my gradle to even compile, I had to bring over my own gradle wrapper. Additionally I was never able to get my dev instance to launch, and could only test that these changes functioned as expected by creating a temporary build jar and using it in an instance of the pack.